### PR TITLE
Static files job per browser support

### DIFF
--- a/app/scripts/use-snow.js
+++ b/app/scripts/use-snow.js
@@ -1,9 +1,5 @@
 // eslint-disable-next-line import/unambiguous
 (function () {
-  // Snow does not support Firefox yet
-  if (window.navigator.userAgent.includes('Firefox')) {
-    return;
-  }
   const log = console.log.bind(console);
   window.top.SNOW((w) => {
     const msg = 'SNOW INTERCEPTED NEW WINDOW CREATION IN METAMASK APP: ';

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -66,6 +66,7 @@ async function defineAndRunBuildTasks() {
     isLavaMoat,
     policyOnly,
     shouldIncludeLockdown,
+    shouldIncludeSnow,
     shouldLintFenceFiles,
     skipStats,
     version,
@@ -81,6 +82,7 @@ async function defineAndRunBuildTasks() {
     livereload,
     browserPlatforms,
     shouldIncludeLockdown,
+    shouldIncludeSnow,
     buildType,
   });
 
@@ -230,6 +232,12 @@ testDev: Create an unoptimized, live-reloading build for debugging e2e tests.`,
             'Whether to include SES lockdown files in the extension bundle. Setting this to `false` can be useful during development if you want to handle lockdown errors later.',
           type: 'boolean',
         })
+        .option('snow', {
+          default: true,
+          description:
+            'Whether to include Snow files in the extension bundle. Setting this to `false` can be useful during development if you want to handle Snow errors later.',
+          type: 'boolean',
+        })
         .option('policy-only', {
           default: false,
           description:
@@ -263,6 +271,7 @@ testDev: Create an unoptimized, live-reloading build for debugging e2e tests.`,
     buildVersion,
     lintFenceFiles,
     lockdown,
+    snow,
     policyOnly,
     skipStats,
     task,
@@ -292,6 +301,7 @@ testDev: Create an unoptimized, live-reloading build for debugging e2e tests.`,
     isLavaMoat: process.argv[0].includes('lavamoat'),
     policyOnly,
     shouldIncludeLockdown: lockdown,
+    shouldIncludeSnow: snow,
     shouldLintFenceFiles,
     skipStats,
     version,

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -15,11 +15,21 @@ module.exports = function createStaticAssetTasks({
   livereload,
   browserPlatforms,
   shouldIncludeLockdown = true,
+  shouldIncludeSnow = true,
   buildType,
 }) {
-  const [copyTargetsProd, copyTargetsDev] = getCopyTargets(
-    shouldIncludeLockdown,
-  );
+  const copyTargetsProds = {};
+  const copyTargetsDevs = {};
+
+  browserPlatforms.forEach((browser) => {
+    const [copyTargetsProd, copyTargetsDev] = getCopyTargets(
+      shouldIncludeLockdown,
+      // Snow currently only works on Chromium based browsers
+      shouldIncludeSnow && browser === 'chrome',
+    );
+    copyTargetsProds[browser] = copyTargetsProd;
+    copyTargetsDevs[browser] = copyTargetsDev;
+  });
 
   const additionalBuildTargets = {
     [BuildType.beta]: [
@@ -37,60 +47,60 @@ module.exports = function createStaticAssetTasks({
   };
 
   if (Object.keys(additionalBuildTargets).includes(buildType)) {
-    copyTargetsProd.push(...additionalBuildTargets[buildType]);
-    copyTargetsDev.push(...additionalBuildTargets[buildType]);
+    Object.entries(copyTargetsProds).forEach(([_, copyTargetsProd]) =>
+      copyTargetsProd.push(...additionalBuildTargets[buildType]),
+    );
+    Object.entries(copyTargetsDevs).forEach(([_, copyTargetsDev]) =>
+      copyTargetsDev.push(...additionalBuildTargets[buildType]),
+    );
   }
 
-  const prod = createTask(
-    TASKS.STATIC_PROD,
-    composeSeries(
-      ...copyTargetsProd.map((target) => {
-        return async function copyStaticAssets() {
-          await performCopy(target);
-        };
-      }),
-    ),
-  );
-  const dev = createTask(
-    TASKS.STATIC_DEV,
-    composeSeries(
-      ...copyTargetsDev.map((target) => {
-        return async function copyStaticAssets() {
-          await setupLiveCopy(target);
-        };
-      }),
-    ),
-  );
+  const prodTasks = [];
+  Object.entries(copyTargetsProds).forEach(([browser, copyTargetsProd]) => {
+    copyTargetsProd.forEach((target) => {
+      prodTasks.push(async function copyStaticAssets() {
+        await performCopy(target, browser);
+      });
+    });
+  });
+
+  const devTasks = [];
+  Object.entries(copyTargetsDevs).forEach(([browser, copyTargetsDev]) => {
+    copyTargetsDev.forEach((target) => {
+      devTasks.push(async function copyStaticAssets() {
+        await setupLiveCopy(target, browser);
+      });
+    });
+  });
+
+  const prod = createTask(TASKS.STATIC_PROD, composeSeries(...prodTasks));
+  const dev = createTask(TASKS.STATIC_DEV, composeSeries(...devTasks));
 
   return { dev, prod };
 
-  async function setupLiveCopy(target) {
+  async function setupLiveCopy(target, browser) {
     const pattern = target.pattern || '/**/*';
     watch(target.src + pattern, (event) => {
       livereload.changed(event.path);
-      performCopy(target);
+      performCopy(target, browser);
     });
-    await performCopy(target);
+    await performCopy(target, browser);
   }
 
-  async function performCopy(target) {
-    await Promise.all(
-      browserPlatforms.map(async (platform) => {
-        if (target.pattern) {
-          await copyGlob(
-            target.src,
-            `${target.src}${target.pattern}`,
-            `./dist/${platform}/${target.dest}`,
-          );
-        } else {
-          await copyGlob(
-            target.src,
-            `${target.src}`,
-            `./dist/${platform}/${target.dest}`,
-          );
-        }
-      }),
-    );
+  async function performCopy(target, browser) {
+    if (target.pattern) {
+      await copyGlob(
+        target.src,
+        `${target.src}${target.pattern}`,
+        `./dist/${browser}/${target.dest}`,
+      );
+    } else {
+      await copyGlob(
+        target.src,
+        `${target.src}`,
+        `./dist/${browser}/${target.dest}`,
+      );
+    }
   }
 
   async function copyGlob(baseDir, srcGlob, dest) {
@@ -104,7 +114,7 @@ module.exports = function createStaticAssetTasks({
   }
 };
 
-function getCopyTargets(shouldIncludeLockdown) {
+function getCopyTargets(shouldIncludeLockdown, shouldIncludeSnow) {
   const allCopyTargets = [
     {
       src: `./app/_locales/`,
@@ -148,11 +158,13 @@ function getCopyTargets(shouldIncludeLockdown) {
       dest: `globalthis.js`,
     },
     {
-      src: `./node_modules/@weizman/snow/snow.prod.js`,
+      src: shouldIncludeSnow
+        ? `./node_modules/@weizman/snow/snow.prod.js`
+        : EMPTY_JS_FILE,
       dest: `snow.js`,
     },
     {
-      src: `./app/scripts/use-snow.js`,
+      src: shouldIncludeSnow ? `./app/scripts/use-snow.js` : EMPTY_JS_FILE,
       dest: `use-snow.js`,
     },
     {


### PR DESCRIPTION
## Issue

File `development/build/static.js` as part of the build process is responsible for setting MetaMask's static files in the `dist` folder. It can change its behaviour based on the type of the build (`prod`/`dev`) but cannot do so based on the type of the platform (`chrome`/`firefox`).

## Solution

This PR modifies `development/build/static.js` to so that it'll have multiple sets of jobs based on the amount of supported platforms (currently `chrome`/`firefox`), so each one could be configured differently if needed.

## Motivation

This PR is being merged into #15580 which introduces [Snow ❄️](https://github.com/lavamoat/snow) support. 
Since Snow only supports Chromium based browsers, a support for a different behaviour in the build process for different browsers was needed (so we could configure the `firefox` build to not include Snow and the `chrome` build to include it).

## Note

In addition to the described motivation above, this PR also already introduces a support for Snow-based differentiating logic in the build system (which successfully demonstrates that this PR works properly)